### PR TITLE
Feat: 사용자 이메일 인증기능추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     //mail-sender
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    //thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 }
 

--- a/src/main/java/com/travelsphere/config/MvcConfiguration.java
+++ b/src/main/java/com/travelsphere/config/MvcConfiguration.java
@@ -1,0 +1,18 @@
+package com.travelsphere.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class MvcConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(final ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/**")
+                .addResourceLocations("classpath:/static/", "classpath:/templates/")
+                .setCacheControl(CacheControl.noCache());
+
+    }
+}

--- a/src/main/java/com/travelsphere/controller/view/UserViewController.java
+++ b/src/main/java/com/travelsphere/controller/view/UserViewController.java
@@ -1,0 +1,30 @@
+package com.travelsphere.controller.view;
+
+import com.travelsphere.service.UserService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@Api(tags = "Email Verification API", description = "이메일 인증과 관련된 API")
+@RequestMapping("/api/v1/users")
+@Controller
+public class UserViewController {
+    private final UserService userService;
+
+    @GetMapping("/{id}/verification")
+    @ApiOperation(value = "사용자 회원인증", notes = "사용자 상태를 '인증' 상태로 변경합니다.")
+    public String verifyUser(@PathVariable Long id, Model model) {
+
+        String message = userService.verifyEmail(id);
+
+        model.addAttribute("message", message);
+
+        return "verification/verification-result";
+    }
+}

--- a/src/main/java/com/travelsphere/domain/User.java
+++ b/src/main/java/com/travelsphere/domain/User.java
@@ -3,10 +3,7 @@ package com.travelsphere.domain;
 import com.travelsphere.dto.UserSignUpRequestDto;
 import com.travelsphere.enums.UserRole;
 import com.travelsphere.enums.UserStatus;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 
@@ -34,9 +31,12 @@ public class User extends BaseEntity {
     private String phone;
 
     @Column
+    @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
     @Column
+    @Setter
+    @Enumerated(EnumType.STRING)
     private UserStatus userStatus;
 
     public static User from(UserSignUpRequestDto userSignUpRequestDto,

--- a/src/main/java/com/travelsphere/enums/VerificationText.java
+++ b/src/main/java/com/travelsphere/enums/VerificationText.java
@@ -1,0 +1,12 @@
+package com.travelsphere.enums;
+
+
+public class VerificationText {
+    public static final String VERIFIED = "인증이 완료되었습니다.";
+
+    public static final String ALREADY_VERIFIED = "이미 인증이 완료된 사용자입니다.";
+
+    public static final String DELETED_USER = "비 활성화 된 사용자입니다.";
+
+    public static final String GO_TO_LOGIN = "앱으로 돌아가 로그인 해주세요.";
+}

--- a/src/main/resources/templates/verification/verification-result.html
+++ b/src/main/resources/templates/verification/verification-result.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <title>회원가입 완료</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+            padding: 0 30px;
+        }
+
+        .message {
+            font-size: 18px;
+            text-align: center;
+            margin: -18px 0 20px;
+        }
+        .message p {
+            margin: 18px 0;
+        }
+
+        .button {
+            background-color: #007275;
+            color: white;
+            padding: 10px 20px;
+            border: none;
+            border-radius: 8px;
+            cursor: pointer;
+            font-size: 16px;
+            text-decoration: none;
+        }
+    </style>
+</head>
+<body>
+<div class="message">
+    <p th:text="${message}"></p>
+    <p>아래 버튼을 눌러 <br>앱에서 로그인 해주세요.</p>
+</div>
+<a class="button" href="https://localhost:8080/">앱으로 돌아가기</a>
+</body>
+</html>

--- a/src/test/java/com/travelsphere/service/UserVerificationServiceTest.java
+++ b/src/test/java/com/travelsphere/service/UserVerificationServiceTest.java
@@ -1,0 +1,65 @@
+package com.travelsphere.service;
+
+import com.travelsphere.domain.User;
+import com.travelsphere.enums.UserRole;
+import com.travelsphere.enums.UserStatus;
+import com.travelsphere.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@DisplayName("이메일인증 테스트")
+class UserVerificationServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        userService = new UserService(userRepository, passwordEncoder);
+    }
+
+    static User user = User.builder()
+            .id(1L)
+            .email("test@test.com")
+            .phone("01012345678")
+            .password("encoded")
+            .userStatus(UserStatus.PENDING)
+            .userRole(UserRole.ROLE_USER)
+            .build();
+
+    static User inactiveUser = User.builder()
+            .id(2L)
+            .email("test@test.com")
+            .phone("01012345678")
+            .password("encoded")
+            .userStatus(UserStatus.ACTIVE)
+            .userRole(UserRole.ROLE_USER)
+            .build();
+
+    @Test
+    @DisplayName("성공")
+    void signUp() {
+        //given
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        //when
+        userService.verifyEmail(user.getId());
+        //then
+        assertThat(user.getUserStatus()).isEqualTo(UserStatus.ACTIVE);
+    }
+
+}


### PR DESCRIPTION
### 작업 내용
- 사용자 이메일을 인증하는 기능 추가
### 변경 사항(추가 시엔 추가 사항)
- 사용자의 상태별로 다른 메세지를 담아 인증완료화면 반환
### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음