### PR TITLE
Feat: 사용자 로그인 기능 추가

### DIFF
--- a/src/main/java/com/travelsphere/controller/UserController.java
+++ b/src/main/java/com/travelsphere/controller/UserController.java
@@ -1,7 +1,6 @@
 package com.travelsphere.controller;
 
-import com.travelsphere.dto.UserDto;
-import com.travelsphere.dto.UserSignUpRequestDto;
+import com.travelsphere.dto.*;
 import com.travelsphere.service.EmailService;
 import com.travelsphere.service.UserService;
 import io.swagger.annotations.Api;
@@ -18,6 +17,7 @@ import javax.validation.Valid;
 import static com.travelsphere.enums.EmailComponents.EMAIL_CONTENT;
 import static com.travelsphere.enums.EmailComponents.EMAIL_SUBJECT;
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
 
 @Api(tags = "User API", description = "사용자 관련 API")
 @RequestMapping("/api/v1/users")
@@ -40,5 +40,15 @@ public class UserController {
                 String.format(EMAIL_CONTENT, userDto.getId()));
 
         return ResponseEntity.status(CREATED).build();
+    }
+
+    @PostMapping("/sign-in")
+    @ApiOperation(value = "사용자 로그인", notes = "사용자 로그인 진행")
+    public ResponseEntity<UserSignInResponseDto> signIn(
+            @Valid @RequestBody UserSignInRequestDto userSignInRequestDto) {
+
+        UserSignInDto userSignInDto = userService.signInUser(userSignInRequestDto);
+
+        return ResponseEntity.status(OK).body(UserSignInResponseDto.from(userSignInDto));
     }
 }

--- a/src/main/java/com/travelsphere/dto/TokenIssuanceDto.java
+++ b/src/main/java/com/travelsphere/dto/TokenIssuanceDto.java
@@ -1,5 +1,6 @@
 package com.travelsphere.dto;
 
+import com.travelsphere.domain.User;
 import com.travelsphere.enums.UserRole;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,4 +11,12 @@ public class TokenIssuanceDto {
     private Long id;
     private String email;
     private UserRole userRole;
+
+    public static TokenIssuanceDto from(User user) {
+        return TokenIssuanceDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .userRole(user.getUserRole())
+                .build();
+    }
 }

--- a/src/main/java/com/travelsphere/dto/UserSignInDto.java
+++ b/src/main/java/com/travelsphere/dto/UserSignInDto.java
@@ -1,0 +1,25 @@
+package com.travelsphere.dto;
+
+import com.travelsphere.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserSignInDto {
+    private Long id;
+    private String email;
+    private String accessToken;
+    private String refreshToken;
+    private String phone;
+
+    public static UserSignInDto from(User user, String AC , String RC) {
+        return UserSignInDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .phone(user.getPhone())
+                .accessToken(AC)
+                .refreshToken(RC)
+                .build();
+    }
+}

--- a/src/main/java/com/travelsphere/dto/UserSignInRequestDto.java
+++ b/src/main/java/com/travelsphere/dto/UserSignInRequestDto.java
@@ -1,0 +1,24 @@
+package com.travelsphere.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserSignInRequestDto {
+    @Email(message = "이메일 형식이 아닙니다.")
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/travelsphere/dto/UserSignInResponseDto.java
+++ b/src/main/java/com/travelsphere/dto/UserSignInResponseDto.java
@@ -1,0 +1,27 @@
+package com.travelsphere.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserSignInResponseDto {
+    private Long id;
+    private String email;
+    private String accessToken;
+    private String refreshToken;
+    private String phone;
+
+    public static UserSignInResponseDto from(UserSignInDto userSignInDto) {
+        return UserSignInResponseDto.builder()
+                .email(userSignInDto.getEmail())
+                .accessToken(userSignInDto.getAccessToken())
+                .refreshToken(userSignInDto.getRefreshToken())
+                .phone(userSignInDto.getPhone())
+                .build();
+    }
+}

--- a/src/main/java/com/travelsphere/exception/ErrorCode.java
+++ b/src/main/java/com/travelsphere/exception/ErrorCode.java
@@ -16,7 +16,9 @@ public enum ErrorCode {
 
     //user
     USER_INFO_NOT_FOUND(NOT_FOUND, "존재하지 않는 사용자입니다."),
-    EXISTING_USER(BAD_REQUEST, "이미 존재하는 사용자입니다.");
+    EXISTING_USER(BAD_REQUEST, "이미 존재하는 사용자입니다."),
+    WRONG_PASSWORD(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    USER_STATUS_NOT_ACTIVE(BAD_REQUEST, "사용자 상태가 활성화되어 있지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/travelsphere/service/UserService.java
+++ b/src/main/java/com/travelsphere/service/UserService.java
@@ -1,17 +1,20 @@
 package com.travelsphere.service;
 
+import com.travelsphere.config.JwtProvider;
 import com.travelsphere.domain.User;
-import com.travelsphere.dto.UserDto;
-import com.travelsphere.dto.UserSignUpRequestDto;
+import com.travelsphere.dto.*;
 import com.travelsphere.enums.UserStatus;
 import com.travelsphere.exception.CustomException;
 import com.travelsphere.exception.ErrorCode;
 import com.travelsphere.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+
+import java.util.concurrent.TimeUnit;
 
 import static com.travelsphere.enums.UserStatus.ACTIVE;
 import static com.travelsphere.enums.VerificationText.*;
@@ -21,6 +24,9 @@ import static com.travelsphere.enums.VerificationText.*;
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final StringRedisTemplate redisTemplate;
+    private final String AUTH_PREFIX = "RC : ";
 
     /**
      * 사용자 회원가입을 처리하는 메서드
@@ -59,7 +65,7 @@ public class UserService {
      */
     @Transactional
     public String verifyEmail(Long userId) {
-        User user = getUser(userId);
+        User user = getUser(userId,null);
         UserStatus userStatus = user.getUserStatus();
 
         if (userStatus.equals(ACTIVE)) {
@@ -82,10 +88,49 @@ public class UserService {
      * @return 주어진 식별자에 해당하는 사용자 정보
      * @throws CustomException 사용자 정보를 찾을 수 없을 때 발생하는 예외
      */
-    private User getUser(Long userId) {
-        return userRepository.findById(userId).orElseThrow(
-                () -> new CustomException(ErrorCode.USER_INFO_NOT_FOUND)
-        );
+    private User getUser(Long userId, String email){
+        if(userId != null){
+            return userRepository.findById(userId).orElseThrow(
+                    () -> new CustomException(ErrorCode.USER_INFO_NOT_FOUND)
+            );
+        } else if (email != null){
+            return userRepository.findByEmail(email).orElseThrow(
+                    () -> new CustomException(ErrorCode.USER_INFO_NOT_FOUND)
+            );
+        } else {
+            throw new CustomException(ErrorCode.USER_INFO_NOT_FOUND);
+        }
     }
 
+    /**
+     * 사용자 로그인을 처리하는 메서드.
+     *
+     * @param userSignInRequestDto 사용자 로그인 요청 정보를 담은 DTO 객체
+     * @return 사용자 로그인 정보를 담은 DTO 객체
+     * @throws CustomException 로그인에 실패했을 때 발생하는 예외 처리
+     */
+    public UserSignInDto signInUser(UserSignInRequestDto userSignInRequestDto) {
+        User user = getUser(null, userSignInRequestDto.getEmail());
+
+        if (!passwordEncoder.matches(userSignInRequestDto.getPassword(), user.getPassword())) {
+            throw new CustomException(ErrorCode.WRONG_PASSWORD);
+        }
+
+        if(!user.getUserStatus().equals(UserStatus.ACTIVE)){
+            throw new CustomException(ErrorCode.USER_STATUS_NOT_ACTIVE);
+        }
+
+        String accessToken = jwtProvider.issueAccessToken(TokenIssuanceDto.from(user));
+        String refreshToken = jwtProvider.issueRefreshToken();
+
+        redisTemplate.opsForValue().set(
+                AUTH_PREFIX + user.getEmail(), refreshToken
+        );
+
+        redisTemplate.expire(
+                AUTH_PREFIX + user.getEmail(), 7, TimeUnit.DAYS
+        );
+
+        return UserSignInDto.from(user,accessToken,refreshToken);
+    }
 }

--- a/src/test/java/com/travelsphere/service/UserSignInServiceTest.java
+++ b/src/test/java/com/travelsphere/service/UserSignInServiceTest.java
@@ -1,0 +1,118 @@
+package com.travelsphere.service;
+
+import com.travelsphere.config.JwtProvider;
+import com.travelsphere.domain.User;
+import com.travelsphere.dto.UserSignInDto;
+import com.travelsphere.dto.UserSignInRequestDto;
+import com.travelsphere.dto.UserSignInResponseDto;
+import com.travelsphere.enums.UserRole;
+import com.travelsphere.enums.UserStatus;
+import com.travelsphere.exception.CustomException;
+import com.travelsphere.exception.ErrorCode;
+import com.travelsphere.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("로그인 테스트")
+class UserSignInServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        userService = new UserService(
+                userRepository, passwordEncoder, jwtProvider, redisTemplate
+        );
+    }
+
+    static User user = User.builder()
+            .id(1L)
+            .email("test@test.com")
+            .phone("01012345678")
+            .password("encoded")
+            .userStatus(UserStatus.ACTIVE)
+            .userRole(UserRole.ROLE_USER)
+            .build();
+
+    @Test
+    @DisplayName("성공")
+    void signIn() {
+        //given
+        UserSignInRequestDto userSignInRequestDto = UserSignInRequestDto.builder()
+                .email(user.getEmail())
+                .password(user.getPassword())
+                .build();
+
+        UserSignInResponseDto userSignInResponseDto = UserSignInResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .accessToken("AC")
+                .refreshToken("RC")
+                .phone(user.getPhone())
+                .build();
+
+        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(user.getPassword(), user.getPassword())).thenReturn(true);
+        when(jwtProvider.issueAccessToken(Mockito.any()))
+                .thenReturn(userSignInResponseDto.getAccessToken());
+        when(jwtProvider.issueRefreshToken())
+                .thenReturn(userSignInResponseDto.getRefreshToken());
+        when(redisTemplate.opsForValue()).thenReturn(mock(ValueOperations.class));
+        when(redisTemplate.expire("RC : " + user.getEmail(), 7, TimeUnit.DAYS))
+                .thenReturn(true);
+
+        //when
+        UserSignInDto userSignInDto = userService.signInUser(userSignInRequestDto);
+        //then
+        assertThat(userSignInDto.getPhone()).isEqualTo(userSignInResponseDto.getPhone());
+        assertThat(userSignInDto.getEmail()).isEqualTo(userSignInResponseDto.getEmail());
+        assertThat(userSignInDto.getAccessToken()).isEqualTo("AC");
+        assertThat(userSignInDto.getRefreshToken()).isEqualTo("RC");
+    }
+
+    @DisplayName("실패")
+    @Test
+    void signInFail() {
+        //given
+        UserSignInRequestDto userSignInRequestDto = UserSignInRequestDto.builder()
+                .email(user.getEmail())
+                .password(user.getPassword())
+                .build();
+
+        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(user.getPassword(), user.getPassword())).thenReturn(false);
+
+        //when&then
+        Assertions.assertThatThrownBy(() -> userService.signInUser(userSignInRequestDto))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.WRONG_PASSWORD.getMessage());
+    }
+}

--- a/src/test/java/com/travelsphere/service/UserSignUpServiceTest.java
+++ b/src/test/java/com/travelsphere/service/UserSignUpServiceTest.java
@@ -1,5 +1,6 @@
 package com.travelsphere.service;
 
+import com.travelsphere.config.JwtProvider;
 import com.travelsphere.domain.User;
 import com.travelsphere.dto.UserDto;
 import com.travelsphere.dto.UserSignUpRequestDto;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
@@ -31,12 +33,20 @@ class UserSignUpServiceTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
     private UserService userService;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.initMocks(this);
-        userService = new UserService(userRepository, passwordEncoder);
+        userService = new UserService(
+                userRepository, passwordEncoder, jwtProvider, redisTemplate
+        );
     }
 
     static UserSignUpRequestDto userSignUpRequestDto = UserSignUpRequestDto.builder()

--- a/src/test/java/com/travelsphere/service/UserVerificationServiceTest.java
+++ b/src/test/java/com/travelsphere/service/UserVerificationServiceTest.java
@@ -1,5 +1,6 @@
 package com.travelsphere.service;
 
+import com.travelsphere.config.JwtProvider;
 import com.travelsphere.domain.User;
 import com.travelsphere.enums.UserRole;
 import com.travelsphere.enums.UserStatus;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
@@ -25,12 +27,20 @@ class UserVerificationServiceTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
     private UserService userService;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.initMocks(this);
-        userService = new UserService(userRepository, passwordEncoder);
+        userService = new UserService(
+                userRepository, passwordEncoder, jwtProvider, redisTemplate
+        );
     }
 
     static User user = User.builder()


### PR DESCRIPTION
### 작업 내용
- 사용자가 이메일과 비밀번호를 사용해 로그인하는 기능 추가
### 변경 사항(추가 시엔 추가 사항)
1. 사용자의 상태 확인
2. 사용자의 비밀번호 일치 여부 확인
3. 사용자 엑세스/리프레시 토큰 발급 및 리프레시토큰 저장
   (만료기간 일주일 - 리프레시토큰 만료기간과 동일)
4. 기본정보와 함께 토큰정보 반환
### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음