### PR TITLE
Feat: 지출 내역 저장하는 기능 추가

### DIFF
--- a/src/main/java/com/travelsphere/component/ExchangeRateScheduler.java
+++ b/src/main/java/com/travelsphere/component/ExchangeRateScheduler.java
@@ -77,6 +77,7 @@ public class ExchangeRateScheduler {
                 double toBuy = jsonNode.get("cashBuyingPrice").asDouble();
                 double toSell = jsonNode.get("cashSellingPrice").asDouble();
                 int currentUnit = jsonNode.get("currencyUnit").asInt();
+                String countryName = jsonNode.get("country").asText();
 
                 return ExchangeRate.builder()
                         .time(time)
@@ -84,7 +85,7 @@ public class ExchangeRateScheduler {
                         .toBuy(toBuy)
                         .toSell(toSell)
                         .currentUnit(currentUnit)
-                        .countryName(country.getCountryName())
+                        .countryName(countryName)
                         .currency(currencyName)
                         .build();
             }

--- a/src/main/java/com/travelsphere/component/ExchangeRateScheduler.java
+++ b/src/main/java/com/travelsphere/component/ExchangeRateScheduler.java
@@ -77,7 +77,6 @@ public class ExchangeRateScheduler {
                 double toBuy = jsonNode.get("cashBuyingPrice").asDouble();
                 double toSell = jsonNode.get("cashSellingPrice").asDouble();
                 int currentUnit = jsonNode.get("currencyUnit").asInt();
-                String countryName = jsonNode.get("country").asText();
 
                 return ExchangeRate.builder()
                         .time(time)
@@ -85,7 +84,7 @@ public class ExchangeRateScheduler {
                         .toBuy(toBuy)
                         .toSell(toSell)
                         .currentUnit(currentUnit)
-                        .countryName(countryName)
+                        .countryName(country.getCountryName())
                         .currency(currencyName)
                         .build();
             }

--- a/src/main/java/com/travelsphere/controller/ExpenseController.java
+++ b/src/main/java/com/travelsphere/controller/ExpenseController.java
@@ -1,10 +1,19 @@
 package com.travelsphere.controller;
 
+import com.travelsphere.dto.ExpenseCreateRequestDto;
 import com.travelsphere.service.ExpenseService;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import static org.springframework.http.HttpStatus.CREATED;
 
 @Api(tags = "Expense API", description = "지출 관련 API")
 @RequestMapping("/api/v1/expenses")
@@ -12,4 +21,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ExpenseController {
     private final ExpenseService expenseService;
+
+    @PostMapping
+    @ApiOperation(value = "지출 등록", notes = "지출을 등록합니다.")
+    public ResponseEntity<Void> createExpense(
+            @Valid @RequestBody ExpenseCreateRequestDto expenseCreateRequestDto) {
+
+        expenseService.createExpense(expenseCreateRequestDto);
+
+        return ResponseEntity.status(CREATED).build();
+    }
 }

--- a/src/main/java/com/travelsphere/domain/Expense.java
+++ b/src/main/java/com/travelsphere/domain/Expense.java
@@ -1,14 +1,17 @@
 package com.travelsphere.domain;
 
+import com.travelsphere.enums.Cities;
+import com.travelsphere.enums.Currencies;
+import com.travelsphere.enums.ExpenseCategories;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import java.sql.Date;
 
 @Getter
 @AllArgsConstructor
@@ -21,4 +24,22 @@ public class Expense extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    private ExpenseCategories category;
+
+    private String currency;
+
+    private Double amount;
+
+    private Double amountOfKrw;
+
+    private Date date;
+
+    private String city;
+
+    private String country;
 }

--- a/src/main/java/com/travelsphere/dto/ExpenseCreateRequestDto.java
+++ b/src/main/java/com/travelsphere/dto/ExpenseCreateRequestDto.java
@@ -1,0 +1,39 @@
+package com.travelsphere.dto;
+
+import com.travelsphere.enums.Cities;
+import com.travelsphere.enums.Currencies;
+import com.travelsphere.enums.ExpenseCategories;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.sql.Date;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ExpenseCreateRequestDto {
+
+    @NotNull(message = "사용자 ID를 입력해주세요.")
+    private Long userId;
+
+    @NotNull(message = "카테고리를 입력해주세요.")
+    private ExpenseCategories category;
+
+    @NotNull(message = "통화를 입력해주세요.")
+    private Currencies currency;
+
+    @Min(value = 1, message = "금액은 0보다 커야합니다.")
+    private Double amount;
+
+    @NotNull(message = "날짜를 입력해주세요.")
+    private Date date;
+
+    @NotNull(message = "도시를 입력해주세요.")
+    private Cities city;
+
+}

--- a/src/main/java/com/travelsphere/enums/ExpenseCategories.java
+++ b/src/main/java/com/travelsphere/enums/ExpenseCategories.java
@@ -1,0 +1,17 @@
+package com.travelsphere.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExpenseCategories {
+    ACCOMMODATION("숙박비"),
+    FOOD("식비"),
+    TRANSPORTATION("교통비"),
+    SHOPPING("쇼핑"),
+    ACTIVITY("액티비티"),
+    ETC("기타");
+
+    private final String categoryName;
+}

--- a/src/main/java/com/travelsphere/service/ExpenseService.java
+++ b/src/main/java/com/travelsphere/service/ExpenseService.java
@@ -1,11 +1,54 @@
 package com.travelsphere.service;
 
+import com.travelsphere.domain.Expense;
+import com.travelsphere.domain.User;
+import com.travelsphere.dto.ExpenseCreateRequestDto;
+import com.travelsphere.enums.Currencies;
+import com.travelsphere.exception.CustomException;
+import com.travelsphere.exception.ErrorCode;
 import com.travelsphere.repository.ExpenseRepository;
+import com.travelsphere.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class ExpenseService {
     private final ExpenseRepository expenseRepository;
+    private final UserRepository userRepository;
+    private final ExchangeRateService exchangeRateService;
+
+    @Transactional
+    public void createExpense(ExpenseCreateRequestDto expenseCreateRequestDto) {
+
+        Double amount = expenseCreateRequestDto.getAmount();
+
+        String currency = expenseCreateRequestDto.getCurrency().getCurrencyName();
+
+        Double amountOfKrw = amount;
+
+        User user = userRepository.findById(expenseCreateRequestDto.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_INFO_NOT_FOUND));
+
+        if (!currency.equals("KRW"))
+            amountOfKrw = exchangeRateService.convertCurrency(
+                    expenseCreateRequestDto.getCurrency(),
+                    Currencies.KRW,
+                    amount
+            );
+
+        Expense expense = Expense.builder()
+                .user(user)
+                .category(expenseCreateRequestDto.getCategory())
+                .currency(currency)
+                .amount(amount)
+                .amountOfKrw(amountOfKrw)
+                .date(expenseCreateRequestDto.getDate())
+                .city(expenseCreateRequestDto.getCity().getCityName())
+                .country(expenseCreateRequestDto.getCity().getCountryName())
+                .build();
+
+        expenseRepository.save(expense);
+    }
 }

--- a/src/test/java/com/travelsphere/service/ExpenseCreationServiceTest.java
+++ b/src/test/java/com/travelsphere/service/ExpenseCreationServiceTest.java
@@ -1,0 +1,85 @@
+package com.travelsphere.service;
+
+import com.travelsphere.domain.ExchangeRate;
+import com.travelsphere.domain.User;
+import com.travelsphere.dto.ExpenseCreateRequestDto;
+import com.travelsphere.enums.*;
+import com.travelsphere.repository.ExchangeRateRepository;
+import com.travelsphere.repository.ExpenseRepository;
+import com.travelsphere.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.sql.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@DisplayName("지출 등록 테스트")
+class ExpenseCreationServiceTest {
+
+    @Mock
+    private ExpenseRepository expenseRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private ExchangeRateService exchangeRateService;
+
+    @Mock
+    private ExchangeRateRepository exchangeRateRepository;
+
+    private ExpenseService expenseService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        exchangeRateService = new ExchangeRateService(exchangeRateRepository);
+        expenseService = new ExpenseService(expenseRepository, userRepository, exchangeRateService);
+    }
+
+    static User user = User.builder()
+            .id(1L)
+            .email("test@test.com")
+            .phone("01012345678")
+            .password("encoded")
+            .userStatus(UserStatus.ACTIVE)
+            .userRole(UserRole.ROLE_USER)
+            .build();
+    static ExchangeRate exchangeRate = ExchangeRate.builder()
+            .countryName("베트남")
+            .currency("VND")
+            .toBuy(5.41)
+            .time("2021-07-01")
+            .basePrice(5.41)
+            .currentUnit(100)
+            .toSell(5.79)
+            .build();
+
+    @Test
+    @DisplayName("성공")
+    void createExpense() {
+        // given
+        ExpenseCreateRequestDto expense = ExpenseCreateRequestDto.builder()
+                .userId(1L)
+                .category(ExpenseCategories.ACTIVITY)
+                .currency(Currencies.MYR)
+                .amount(100.0)
+                .date(Date.valueOf("2021-01-01"))
+                .city(Cities.KUALA_LUMPUR)
+                .build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(exchangeRateRepository.findByCurrency("MYR")).thenReturn(List.of(exchangeRate));
+        // when
+        expenseService.createExpense(expense);
+        // then
+        verify(expenseRepository, times(1)).save(Mockito.any());
+    }
+
+}


### PR DESCRIPTION
### 작업 내용
- 지출내역을 저장하는 기능을 추가
### 변경 사항(추가 시엔 추가 사항)
- 추후 통계를 위해 카테고리, 통화 등 의 필드를 구분하고
  입력된 통화가 원화가 아닐경우 원화로 환산하여 추가 저장
### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음