### PR TITLE
Feat: 도시 별 각 카테고리의 사용자들의 평균소비금액 추가/조회하는 기능 추가

### DIFF
--- a/src/main/java/com/travelsphere/component/ExchangeRateScheduler.java
+++ b/src/main/java/com/travelsphere/component/ExchangeRateScheduler.java
@@ -77,6 +77,7 @@ public class ExchangeRateScheduler {
                 double toBuy = jsonNode.get("cashBuyingPrice").asDouble();
                 double toSell = jsonNode.get("cashSellingPrice").asDouble();
                 int currentUnit = jsonNode.get("currencyUnit").asInt();
+                String countryName = jsonNode.get("country").asText();
 
                 return ExchangeRate.builder()
                         .time(time)
@@ -84,7 +85,7 @@ public class ExchangeRateScheduler {
                         .toBuy(toBuy)
                         .toSell(toSell)
                         .currentUnit(currentUnit)
-                        .countryName(country.getCountryName())
+                        .countryName(countryName)
                         .currency(currencyName)
                         .build();
             }

--- a/src/main/java/com/travelsphere/component/ExchangeRateScheduler.java
+++ b/src/main/java/com/travelsphere/component/ExchangeRateScheduler.java
@@ -77,7 +77,6 @@ public class ExchangeRateScheduler {
                 double toBuy = jsonNode.get("cashBuyingPrice").asDouble();
                 double toSell = jsonNode.get("cashSellingPrice").asDouble();
                 int currentUnit = jsonNode.get("currencyUnit").asInt();
-                String countryName = jsonNode.get("country").asText();
 
                 return ExchangeRate.builder()
                         .time(time)
@@ -85,7 +84,7 @@ public class ExchangeRateScheduler {
                         .toBuy(toBuy)
                         .toSell(toSell)
                         .currentUnit(currentUnit)
-                        .countryName(countryName)
+                        .countryName(country.getCountryName())
                         .currency(currencyName)
                         .build();
             }

--- a/src/main/java/com/travelsphere/controller/ExpenseController.java
+++ b/src/main/java/com/travelsphere/controller/ExpenseController.java
@@ -6,6 +6,7 @@ import com.travelsphere.dto.ExpenseDto;
 import com.travelsphere.dto.ExpenseInquiryResponseDto;
 import com.travelsphere.dto.ExpenseModificationRequestDto;
 import com.travelsphere.service.ExpenseService;
+import com.travelsphere.service.StatisticsService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import static org.springframework.http.HttpStatus.*;
 @RestController
 public class ExpenseController {
     private final ExpenseService expenseService;
+    private final StatisticsService statisticsService;
     private final JwtProvider jwtProvider;
 
     /**
@@ -42,6 +44,8 @@ public class ExpenseController {
 
         Long userId = jwtProvider.getIdFromToken(token);
         expenseService.createExpense(userId, expenseCreateRequestDto);
+
+        statisticsService.updateStatistics(expenseCreateRequestDto);
 
         return ResponseEntity.status(CREATED).build();
     }

--- a/src/main/java/com/travelsphere/controller/StatisticsController.java
+++ b/src/main/java/com/travelsphere/controller/StatisticsController.java
@@ -1,10 +1,19 @@
 package com.travelsphere.controller;
 
+import com.travelsphere.dto.StatisticsDto;
+import com.travelsphere.dto.StatisticsExpenseResponseDto;
+import com.travelsphere.enums.Cities;
 import com.travelsphere.service.StatisticsService;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpStatus.OK;
 
 @Api(tags = "Statistics API", description = "통계 관련 API")
 @RequestMapping("/api/v1/statistics")
@@ -12,4 +21,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class StatisticsController {
     private final StatisticsService statisticsService;
+
+    /**
+     * 도시별 평균 소비금액 조회
+     * @param cityName 도시명
+     * @param token jwt 토큰
+     * @return ResponseEntity<StatisticsExpenseResponseDto>
+     */
+    @GetMapping("/cities/{cityName}")
+    @ApiOperation(value = "도시별 평균 소비금액 조회", notes = "도시별 평균 소비금액 통계를 조회합니다.")
+    public ResponseEntity<StatisticsExpenseResponseDto> getStatisticsByCity(
+            @PathVariable Cities cityName,
+            @RequestHeader(AUTHORIZATION) String token) {
+
+        List<StatisticsDto> expenses =
+                statisticsService.getStatisticsByCity(cityName);
+
+        return ResponseEntity.status(OK)
+                .body(StatisticsExpenseResponseDto.from(expenses));
+    }
 }

--- a/src/main/java/com/travelsphere/domain/Statistics.java
+++ b/src/main/java/com/travelsphere/domain/Statistics.java
@@ -1,14 +1,9 @@
 package com.travelsphere.domain;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.travelsphere.enums.ExpenseCategories;
+import lombok.*;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Getter
 @AllArgsConstructor
@@ -21,4 +16,19 @@ public class Statistics extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
+    private String country;
+
+    @Setter
+    private String city;
+
+    @Setter
+    private Long numberOfExpenses;
+
+    @Setter
+    @Enumerated(EnumType.STRING)
+    private ExpenseCategories category;
+
+    @Setter
+    private Double averageAmountInKrw;
 }

--- a/src/main/java/com/travelsphere/dto/StatisticsDto.java
+++ b/src/main/java/com/travelsphere/dto/StatisticsDto.java
@@ -1,0 +1,29 @@
+package com.travelsphere.dto;
+
+import com.travelsphere.domain.Statistics;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class StatisticsDto {
+    private String country;
+    private String city;
+    private Long numberOfExpenses;
+    private String category;
+    private Double averageAmountInKrw;
+
+    public static StatisticsDto from(Statistics statistics) {
+        return StatisticsDto.builder()
+                .country(statistics.getCountry())
+                .city(statistics.getCity())
+                .numberOfExpenses(statistics.getNumberOfExpenses())
+                .category(statistics.getCategory().getCategoryName())
+                .averageAmountInKrw(statistics.getAverageAmountInKrw())
+                .build();
+    }
+}

--- a/src/main/java/com/travelsphere/dto/StatisticsExpenseResponseDto.java
+++ b/src/main/java/com/travelsphere/dto/StatisticsExpenseResponseDto.java
@@ -1,0 +1,22 @@
+package com.travelsphere.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class StatisticsExpenseResponseDto {
+    private List<StatisticsDto> statistics;
+
+    public static StatisticsExpenseResponseDto from(List<StatisticsDto> statistics) {
+        return StatisticsExpenseResponseDto.builder()
+                .statistics(statistics)
+                .build();
+    }
+}

--- a/src/main/java/com/travelsphere/repository/StatisticsRepository.java
+++ b/src/main/java/com/travelsphere/repository/StatisticsRepository.java
@@ -5,10 +5,13 @@ import com.travelsphere.enums.ExpenseCategories;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface StatisticsRepository extends JpaRepository<Statistics, Long> {
     Optional<Statistics> findByCityAndCategory(String cityName, ExpenseCategories category);
 
+    List<Statistics> findByCity(String cityName);
 }

--- a/src/main/java/com/travelsphere/repository/StatisticsRepository.java
+++ b/src/main/java/com/travelsphere/repository/StatisticsRepository.java
@@ -1,9 +1,14 @@
 package com.travelsphere.repository;
 
 import com.travelsphere.domain.Statistics;
+import com.travelsphere.enums.ExpenseCategories;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface StatisticsRepository extends JpaRepository<Statistics, Long> {
+    Optional<Statistics> findByCityAndCategory(String cityName, ExpenseCategories category);
+
 }

--- a/src/main/java/com/travelsphere/service/ExchangeRateService.java
+++ b/src/main/java/com/travelsphere/service/ExchangeRateService.java
@@ -63,7 +63,7 @@ public class ExchangeRateService {
         double basePrice = exchangeRate.getBasePrice();
 
         while (currentUnit > 1) {
-            basePrice = basePrice * 10;
+            basePrice = basePrice / 10;
             currentUnit = currentUnit / 10;
         }
 

--- a/src/main/java/com/travelsphere/service/StatisticsService.java
+++ b/src/main/java/com/travelsphere/service/StatisticsService.java
@@ -2,11 +2,18 @@ package com.travelsphere.service;
 
 import com.travelsphere.domain.Statistics;
 import com.travelsphere.dto.ExpenseCreateRequestDto;
+import com.travelsphere.dto.StatisticsDto;
+import com.travelsphere.enums.Cities;
 import com.travelsphere.enums.Currencies;
+import com.travelsphere.enums.ExpenseCategories;
 import com.travelsphere.repository.StatisticsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -52,4 +59,10 @@ public class StatisticsService {
         statisticsRepository.save(statistics);
     }
 
+    @Transactional(readOnly = true)
+    public List<StatisticsDto> getStatisticsByCity(Cities cityName) {
+        return statisticsRepository.findByCity(cityName.getCityName()).stream()
+                .map(StatisticsDto::from)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/travelsphere/service/StatisticsService.java
+++ b/src/main/java/com/travelsphere/service/StatisticsService.java
@@ -1,11 +1,55 @@
 package com.travelsphere.service;
 
+import com.travelsphere.domain.Statistics;
+import com.travelsphere.dto.ExpenseCreateRequestDto;
+import com.travelsphere.enums.Currencies;
 import com.travelsphere.repository.StatisticsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class StatisticsService {
     private final StatisticsRepository statisticsRepository;
+    private final ExchangeRateService exchangeRateService;
+
+    /**
+     * 통계를 업데이트한다. (각 도시 카테고리 별)
+     *
+     * @param expenseCreateRequestDto 지출 등록 요청 DTO
+     */
+    @Transactional
+    public void updateStatistics(ExpenseCreateRequestDto expenseCreateRequestDto) {
+        Statistics statistics =
+                statisticsRepository.findByCityAndCategory(
+                                expenseCreateRequestDto.getCity().getCityName(),
+                                expenseCreateRequestDto.getCategory()
+                        )
+                        .orElseGet(() -> Statistics.builder()
+                                .city(expenseCreateRequestDto.getCity().getCityName())
+                                .country(expenseCreateRequestDto.getCity().getCountryName())
+                                .category(expenseCreateRequestDto.getCategory())
+                                .build()
+                        );
+
+        Double amount = exchangeRateService.convertCurrency(
+                expenseCreateRequestDto.getCurrency(),
+                Currencies.KRW,
+                expenseCreateRequestDto.getAmount()
+        );
+
+        long numbers =
+                statistics.getNumberOfExpenses() == null ? 0L : statistics.getNumberOfExpenses();
+
+        statistics.setNumberOfExpenses(numbers + 1);
+
+        double totalAmount =
+                statistics.getAverageAmountInKrw() == null ? 0.0 : statistics.getAverageAmountInKrw();
+
+        statistics.setAverageAmountInKrw((totalAmount * numbers + amount) / (numbers + 1));
+
+        statisticsRepository.save(statistics);
+    }
+
 }

--- a/src/test/java/com/travelsphere/service/StatisticsCitiesServiceTest.java
+++ b/src/test/java/com/travelsphere/service/StatisticsCitiesServiceTest.java
@@ -1,0 +1,95 @@
+package com.travelsphere.service;
+
+import com.travelsphere.domain.ExchangeRate;
+import com.travelsphere.dto.ExpenseCreateRequestDto;
+import com.travelsphere.repository.ExchangeRateRepository;
+import com.travelsphere.repository.StatisticsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static com.travelsphere.enums.Cities.BANGKOK;
+import static com.travelsphere.enums.Cities.KUALA_LUMPUR;
+import static com.travelsphere.enums.Currencies.KRW;
+import static com.travelsphere.enums.Currencies.MYR;
+import static com.travelsphere.enums.ExpenseCategories.ETC;
+import static org.mockito.Mockito.*;
+
+@DisplayName("도시별 평균 소비금액 저장 테스트")
+class StatisticsCitiesServiceTest {
+    @Mock
+    private StatisticsRepository statisticsRepository;
+
+    private StatisticsService statisticsService;
+
+    @Mock
+    private ExchangeRateService exchangeRateService;
+
+    @Mock
+    private ExchangeRateRepository exchangeRateRepository;
+
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        statisticsService = new StatisticsService(
+                statisticsRepository, exchangeRateService
+        );
+    }
+
+    ExpenseCreateRequestDto expenseCreateRequestDto = ExpenseCreateRequestDto.builder()
+            .city(BANGKOK)
+            .category(ETC)
+            .currency(MYR)
+            .amount(1000.0)
+            .build();
+
+    ExchangeRate exchangeRate1 = ExchangeRate.builder()
+            .countryName("베트남")
+            .currency("MYR")
+            .toBuy(5.41)
+            .time("2021-07-01 11:00:00")
+            .basePrice(5.41)
+            .currentUnit(100)
+            .toSell(5.79)
+            .build();
+
+    ExchangeRate exchangeRate2 = ExchangeRate.builder()
+            .countryName("베트남")
+            .currency("VND")
+            .toBuy(5.41)
+            .time("2021-07-01 11:00:00")
+            .basePrice(5.41)
+            .currentUnit(100)
+            .toSell(5.79)
+            .build();
+
+    @Test
+    @DisplayName("성공")
+    void getStatisticsByCity() {
+        // given
+        when(statisticsRepository.findByCityAndCategory(KUALA_LUMPUR.getCityName(), ETC))
+                .thenReturn(null);
+        when(exchangeRateService.convertCurrency(MYR, KRW, 1000.0))
+                .thenReturn(5000.0);
+        when(statisticsRepository.save(Mockito.any()))
+                .thenReturn(null);
+        when(exchangeRateRepository.findByCurrency(MYR.getCurrencyName()))
+                .thenReturn(List.of(exchangeRate1));
+        when(exchangeRateRepository.findByCurrency(KRW.getCurrencyName()))
+                .thenReturn(List.of(exchangeRate2));
+        when(exchangeRateService.convertCurrency(MYR, KRW, 1000.0))
+                .thenReturn(5000.0);
+
+        // when
+        statisticsService.updateStatistics(expenseCreateRequestDto);
+        // then
+        verify(statisticsRepository, times(1))
+                .save(Mockito.any());
+    }
+}


### PR DESCRIPTION
### 작업 내용
- 도시 별 각 카테고리의 사용자들의 평균소비금액 추가/조회하는 기능 추가
### 변경 사항(추가 시엔 추가 사항)
- 지출 등록 시 평균소비금액을 저장하는 로직 추가
- 이후 지역 설정 시 평균 소비금액을 보여줘서 사용자의 예산설정에 도움이되도록 할 예정
### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음